### PR TITLE
fix: Color scoping

### DIFF
--- a/src/app/(canvaGroup)/canva/(canvaMainGroup)/canva-variables.css
+++ b/src/app/(canvaGroup)/canva/(canvaMainGroup)/canva-variables.css
@@ -1,4 +1,4 @@
-:root {
+.theme-canva {
   --palette-primary: #7d2ae8;
   --palette-primary-dark: #6318c5;
   --palette-secondary: #280f91;

--- a/src/app/(canvaGroup)/canva/(canvaMainGroup)/layout.tsx
+++ b/src/app/(canvaGroup)/canva/(canvaMainGroup)/layout.tsx
@@ -23,7 +23,7 @@ export default function CanvaLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className={`${ezra.variable} sans-serif`}>
+    <div className={`${ezra.variable} sans-serif theme-canva`}>
       <Header headerFor="canva" navLinks={CANVA_NAV_LINKS} />
       {children}
       <Footer />

--- a/src/app/(homeGroup)/home-variables.css
+++ b/src/app/(homeGroup)/home-variables.css
@@ -1,7 +1,8 @@
 /* @link spaces https://utopia.fyi/space/calculator?c=320,18,1.2,1240,20,1.25,5,2,1887&s=0.75|0.5|0.4|0.25,1.5|2|3|4|6|8|10,s-l&g=s,l,xl,12 */
 /* @link typography https://utopia.fyi/type/calculator?c=320,16,1.25,1400,20,1.25,8,2,1200&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l&g=s,l,xl,12 */
 
-:root {
+:root,
+.theme-home {
   /* palette */
   --palette-primary: #1b5452;
   --palette-primary-dark: #124341;

--- a/src/app/(homeGroup)/layout.tsx
+++ b/src/app/(homeGroup)/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
 
 export default function HomeLayout({ children }: PropsWithChildren) {
   return (
-    <div className={`${arvo.variable} ${raleway.variable}`}>
+    <div className={`${arvo.variable} ${raleway.variable} theme-home`}>
       <Header headerFor="normal" navLinks={NAV_LINKS} />
       {children}
       <AGradient />


### PR DESCRIPTION
This pull request introduces theme-specific CSS class names for the `canva` and `home` sections, allowing for more modular and scoped styling. The most important changes include updates to the CSS variable definitions and modifications to the layout components to apply the new theme classes.

### Theme-specific CSS updates:

* [`src/app/(canvaGroup)/canva/(canvaMainGroup)/canva-variables.css`](diffhunk://#diff-3aec218969e41d7ca18f2a10df778ce2ecf2bfe520a75a70f54ddf2649bb1142L1-R1): Replaced the `:root` selector with `.theme-canva` to scope the CSS variables specifically to the `canva` theme.
* [`src/app/(homeGroup)/home-variables.css`](diffhunk://#diff-29150a3ecfa609aa4efa3411787807915b558384ec58d48a15715b4565f82192L4-R5): Added `.theme-home` alongside `:root` to scope the CSS variables specifically to the `home` theme.

### Layout component updates:

* [`src/app/(canvaGroup)/canva/(canvaMainGroup)/layout.tsx`](diffhunk://#diff-4165b16b54adb48f65727ca62d25259e145a89482ddcfd7e0d5a03ad44724c14L26-R26): Updated the wrapping `div` to include the `theme-canva` class for applying the scoped `canva` theme styles.
* [`src/app/(homeGroup)/layout.tsx`](diffhunk://#diff-7ebd04b9a3a438998011bc808532f6c31a66710d82a39c8981758fb093026eacL33-R33): Updated the wrapping `div` to include the `theme-home` class for applying the scoped `home` theme styles.